### PR TITLE
[Feature] Window Size

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,10 +36,8 @@ enable_flight = false
 [window]
 # Title of the window
 title = "Woop"
-# Default window resolution. This also affects the
-# resolution of the output image, so be wary of
-# performance costs.
-resolution = [320, 200]
+# Size of the window
+size = [2560, 1440]
 # Whether the window should be fullscreen
 fullscreen = false
 # Whether the window should be resizable
@@ -62,6 +60,9 @@ vertex_shader = "assets/shaders/vert.glsl"
 # Path to the fragment shader used to render the 
 # output iamge
 fragment_shader = "assets/shaders/frag.glsl"
+# Resolution of the output image. Be wary of
+# performance when increasing this.
+resolution = [320, 200]
 # Color used to clear the screen
 clear_color = [0, 0, 0]
 # Color of fog in the level

--- a/config.toml
+++ b/config.toml
@@ -11,8 +11,8 @@
 
 # These values are required!
 [general]
-wad = "path/to/your/wad"
-level = "LEVELNAME"
+wad = "assets/wads/doom1.wad"
+level = "E1M1"
 
 [player]
 # How tall the player is
@@ -37,9 +37,9 @@ enable_flight = false
 # Title of the window
 title = "Woop"
 # Size of the window
-size = [2560, 1440]
+size = [1280, 720]
 # Whether the window should be fullscreen
-fullscreen = false
+fullscreen = true
 # Whether the window should be resizable
 resizable = true
 # Whether the window should be decorated

--- a/include/renderer.hpp
+++ b/include/renderer.hpp
@@ -223,6 +223,7 @@ struct RendererConfig {
     std::string vert_src = "";
     std::string frag_src = "";
   } shaders;
+  glm::uvec2 resolution = {320, 200};
   Pixel clear_color = Pixel{0, 0, 0, 255};
   Pixel fill_color = Pixel{255, 255, 255, 255};
   Pixel fog_color = clear_color;
@@ -331,7 +332,6 @@ class Renderer {
   RendererConfig config;
   Window& window;
   Camera& camera;
-  glm::uvec2 size;
   DisplayRect display_rect;
   unsigned pbo_back;
   unsigned pbo_front;

--- a/include/window.hpp
+++ b/include/window.hpp
@@ -41,7 +41,7 @@ struct WindowException : public Exception {
  */
 struct WindowConfig {
   std::string title = "Woop";
-  glm::ivec2 resolution = {320, 200};
+  glm::ivec2 size = {1280, 720};
   bool fullscreen = false;
   bool resizable = true;
   bool decorated = true;
@@ -68,8 +68,8 @@ class Window {
   std::string get_title() const noexcept;
   void set_title(const std::string& new_title) noexcept;
 
-  glm::ivec2 get_resolution() const noexcept;
-  void set_resolution(const glm::ivec2& new_resolution) noexcept;
+  glm::ivec2 get_size() const noexcept;
+  void set_size(const glm::ivec2& new_size) noexcept;
 
   float get_aspect_ratio() const;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,12 +56,12 @@ woop::WindowConfig get_window_config(const toml::table& table) {
   if (const auto& entry = table["window"]["title"].value<std::string>())
     cfg.title = entry.value();
   // Resolution
-  if (const auto* entry = table["window"]["resolution"].as_array()) {
+  if (const auto* entry = table["window"]["size"].as_array()) {
     try {
-      cfg.resolution = get_array_as_ivec2(*entry);
+      cfg.size = get_array_as_ivec2(*entry);
     } catch (std::exception& exception) {
       throw ConfigException(
-          "Invalid value given to \"window.resolution\" (expected [width, "
+          "Invalid value given to \"window.size\" (expected [width, "
           "height])");
     }
   }
@@ -99,6 +99,20 @@ woop::RendererConfig get_renderer_config(const toml::table& table) {
   if (const auto& entry =
           table["renderer"]["fragment_shader"].value<std::string>())
     cfg.shaders.frag_path = entry.value();
+  // Resolution
+  if (const auto* entry = table["renderer"]["resolution"].as_array()) {
+    glm::ivec2 resolution;
+    try {
+      resolution = get_array_as_ivec2(*entry);
+    } catch (std::exception& exception) {
+      throw ConfigException(
+          "Invalid value given to \"renderer.resolution\" (expected [width, "
+          "height])");
+    }
+    if (resolution.x < 0 || resolution.y < 0)
+      throw ConfigException("Renderer resolution must be positive.");
+    cfg.resolution = resolution;
+  }
   // Clear color
   if (const auto* entry = table["renderer"]["clear_color"].as_array()) {
     try {

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -446,8 +446,6 @@ Renderer::Renderer(Window& wdw, Camera& cam, const RendererConfig& cfg)
     : config(cfg),
       window(wdw),
       camera(cam),
-      size(static_cast<unsigned>(window.get_resolution().x),
-           static_cast<unsigned>(window.get_resolution().y)),
       display_rect(*this, get_shader_from_cfg(cfg)) {
   // Shaders are only guaranteed to support 16 texture units.
   if (cfg.texture_unit > 16)
@@ -455,7 +453,7 @@ Renderer::Renderer(Window& wdw, Camera& cam, const RendererConfig& cfg)
         RenderException::Type::InvalidConfig,
         "Attempting to bind renderer to an invalid texture index.");
   screen_plane_distance =
-      static_cast<float>(size.x) / 2.0f /
+      static_cast<float>(config.resolution.x) / 2.0f /
       static_cast<float>(std::tan(glm::radians(camera.get_fov() / 2.0f)));
   gen_pbos();
 }
@@ -466,10 +464,10 @@ Frame Renderer::begin_frame() {
   return frame;
 }
 glm::uvec2 Renderer::get_img_size() const noexcept {
-  return size;
+  return config.resolution;
 }
 std::size_t Renderer::get_pixel_count() const noexcept {
-  return size.x * size.y;
+  return config.resolution.x * config.resolution.y;
 }
 unsigned Renderer::get_texture_unit() const noexcept {
   return config.texture_unit;

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -18,6 +18,9 @@ Window::Window(const WindowConfig& cfg) : config(cfg) {
     init_glad();
   set_callbacks();
   ++num_windows;
+
+  // Set viewport size
+  glViewport(0, 0, config.size.x, config.size.y);
 }
 Window::~Window() {
   glfwDestroyWindow(window);

--- a/src/core/window.cpp
+++ b/src/core/window.cpp
@@ -31,17 +31,17 @@ std::string Window::get_title() const noexcept {
 void Window::set_title(const std::string& new_title) noexcept {
   glfwSetWindowTitle(window, new_title.c_str());
 }
-glm::ivec2 Window::get_resolution() const noexcept {
+glm::ivec2 Window::get_size() const noexcept {
   glm::ivec2 out;
   glfwGetWindowSize(window, &out.x, &out.y);
   return out;
 }
-void Window::set_resolution(const glm::ivec2& new_resolution) noexcept {
-  glfwSetWindowSize(window, new_resolution.x, new_resolution.y);
+void Window::set_size(const glm::ivec2& new_size) noexcept {
+  glfwSetWindowSize(window, new_size.x, new_size.y);
 }
 float Window::get_aspect_ratio() const {
-  float x = static_cast<float>(get_resolution().x);
-  float y = static_cast<float>(get_resolution().y);
+  float x = static_cast<float>(get_size().x);
+  float y = static_cast<float>(get_size().y);
   if (y == 0)
     throw WindowException(WindowException::Type::Other,
                           "Window has no vertical size (is it minimized?)");
@@ -71,8 +71,8 @@ void Window::init_window() {
   GLFWmonitor* monitor = nullptr;
   if (config.fullscreen)
     monitor = glfwGetPrimaryMonitor();
-  window = glfwCreateWindow(config.resolution.x, config.resolution.y,
-                            config.title.c_str(), monitor, NULL);
+  window = glfwCreateWindow(config.size.x, config.size.y, config.title.c_str(),
+                            monitor, NULL);
   if (!window) {
     if (num_windows == 0)
       shutdown_glfw();


### PR DESCRIPTION
Added a "window size" option to configuration. Window size is no longer tied to renderer resolution, meaning you can make your window as big as you like without impacting performance!
Fixed bug where fullscreen windows would only render the lower left quarter of the output image.
Closes #24